### PR TITLE
Adjust formula to better follow Homebrew PR's audit

### DIFF
--- a/Formula/benerator.rb
+++ b/Formula/benerator.rb
@@ -5,34 +5,37 @@ class Benerator < Formula
   sha256 "194feb051ae18cfcd407b8e1668ce9c60561394bc454f9fc9747c274166843bc"
 
   license "Apache-2.0"
-  depends_on "openjdk"
+  depends_on "openjdk@11"
   def install
     # Remove unnecessary files
-    rm Dir["bin/*.bat", "bin/pom.xml"]
+    rm_f Dir["bin/*.bat", "bin/pom.xml"]
 
     # Installs only the 'bin' and 'lib' directories from the tarball
     # Creates the symlinks to 'bin' scripts in /usr/local/bin
     # Creates the symlink to the installation path in /usr/local/opt
-    prefix.install Dir["bin", "lib"]
+    libexec.install Dir["bin", "lib"]
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    # Remove non-executable files
+    rm_f "#{bin}/benerator_common"
+    rm_f "#{bin}/log4j2.xml"
   end
 
   # opt_prefix is set to the symlink /usr/local/opt/benerator
   def caveats
     <<~EOS
       To use the benerator commands, please set the following environment variables:
-      BENERATOR_HOME=#{opt_prefix}
 
-      Use one of the following commands to find the value for JAVA_HOME:
-      $(dirname $(readlink $(which javac)))/java_home
+      BENERATOR_HOME="#{libexec}"
+      JAVA_HOME="$(/usr/libexec/java_home -v 11)"
 
-      or (more platform independent)
-
-      java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home'
-
+      For more information, see:
+      https://github.com/rapiddweller/rapiddweller-benerator-ce
     EOS
   end
 
   test do
-    assert_match "Benerator 3.1.0-jdk-11", shell_output("#{bin}/benerator --version", 2)
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+    ENV["BENERATOR_HOME"] = libexec.to_s
+    assert_match "Benerator Community Edition 3.1.0-jdk-11", shell_output("#{libexec}/bin/benerator --version")
   end
 end


### PR DESCRIPTION
- Non-executable files should not be installed in bin
- Java executable files should be install in libexec and symlinks to
  bin
- modify "openjdk@11" to make sure it Java 11 or higher when install
- modify EOS to make it easier for user to set up environment variable
  after installation
- Test should include ENV set up to perform check correctly